### PR TITLE
Use procedural-macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   'gd-tools',
   'gd-engine',
   'gd-world',
+  'gd-world-derive',
 ]
 
 [profile.release]

--- a/gd-cli/src/params.rs
+++ b/gd-cli/src/params.rs
@@ -63,7 +63,7 @@ mod tests {
     use serde_test::{assert_de_tokens, Token};
 
     #[test]
-    fn test_deserialize_provider_behaviour() {
+    fn deserialize_provider_behaviour() {
         assert_de_tokens(
             &ProviderBehaviour::Regular,
             &[
@@ -99,7 +99,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deserialize_fixed() {
+    fn deserialize_fixed() {
         assert_de_tokens(
             &Generator::Fixed(1.0),
             &[
@@ -111,7 +111,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deserialize_choice() {
+    fn deserialize_choice() {
         assert_de_tokens(
             &Generator::Choice(vec![0.5, 1.0, 2.0]),
             &[
@@ -127,7 +127,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deserialize_uniform() {
+    fn deserialize_uniform() {
         assert_de_tokens(
             &Generator::Uniform(1.0, 2.0),
             &[
@@ -142,7 +142,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deserialize_lognormal() {
+    fn deserialize_lognormal() {
         assert_de_tokens(
             &Generator::LogNormal(0.0, 1.0),
             &[
@@ -157,7 +157,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deserialize_normal() {
+    fn deserialize_normal() {
         assert_de_tokens(
             &Generator::Normal(0.0, 0.5),
             &[
@@ -172,7 +172,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deserialize_exp() {
+    fn deserialize_exp() {
         assert_de_tokens(
             &Generator::Exp(1.0),
             &[

--- a/gd-engine/src/lib.rs
+++ b/gd-engine/src/lib.rs
@@ -84,7 +84,7 @@ mod tests {
     use super::*;
 
     #[test]
-    pub fn test_event_queue() {
+    pub fn event_queue() {
         let mut engine = Engine::new();
         assert!(engine.events.is_empty());
         assert_eq!(engine.now(), 0.0);

--- a/gd-tools/src/partition.rs
+++ b/gd-tools/src/partition.rs
@@ -142,7 +142,7 @@ mod tests {
     }
 
     #[test]
-    fn test_matches() {
+    fn matches() {
         let into = |tv: &TestValue| tv.item();
 
         let partition = Partition::new(None);
@@ -173,7 +173,7 @@ mod tests {
     }
 
     #[test]
-    fn test_degenerate_partition() {
+    fn degenerate_partition() {
         let partitions = partition(Vec::<TestValue>::new(), &[0.0, 0.25]);
         assert!(partitions.is_empty());
 
@@ -191,7 +191,7 @@ mod tests {
     }
 
     #[test]
-    fn test_partition() {
+    fn valid_partition() {
         let values = vec![
             TestValue(0.15),
             TestValue(0.45),

--- a/gd-tools/src/stats.rs
+++ b/gd-tools/src/stats.rs
@@ -49,7 +49,7 @@ mod tests {
     use statrs::assert_almost_eq;
 
     #[test]
-    fn test_confidence_interval_for_mean() {
+    fn confidence_interval_for_mean() {
         let values = &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let ci = values.confidence_interval_for_mean(0.95);
         assert_almost_eq!(1.963, ci, 1e-3);

--- a/gd-world-derive/Cargo.toml
+++ b/gd-world-derive/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "gd-world-derive"
+version = "0.1.0"
+authors = ["Jakub Konka <kubkon@jakubkonka.com>"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "0.14"
+quote = "0.6"

--- a/gd-world-derive/src/lib.rs
+++ b/gd-world-derive/src/lib.rs
@@ -1,0 +1,60 @@
+extern crate proc_macro;
+
+use crate::proc_macro::TokenStream;
+use quote::quote;
+
+#[proc_macro_derive(DerefDefenceMechanismCommon)]
+pub fn deref_defence_mechanism_common_derive(input: TokenStream) -> TokenStream {
+    let ast = syn::parse(input).unwrap();
+
+    impl_deref_defence_mechanism_common(&ast)
+}
+
+fn impl_deref_defence_mechanism_common(ast: &syn::DeriveInput) -> TokenStream {
+    let name = &ast.ident;
+    let gen = quote! {
+        impl std::ops::Deref for #name {
+            type Target = DefenceMechanismCommon;
+
+            fn deref(&self) -> &DefenceMechanismCommon {
+                self.as_dm_common()
+            }
+        }
+
+        impl std::ops::DerefMut for #name {
+            fn deref_mut(&mut self) -> &mut DefenceMechanismCommon {
+                self.as_dm_common_mut()
+            }
+        }
+    };
+
+    gen.into()
+}
+
+#[proc_macro_derive(DerefProviderCommon)]
+pub fn deref_provider_common_derive(input: TokenStream) -> TokenStream {
+    let ast = syn::parse(input).unwrap();
+
+    impl_deref_provider_common(&ast)
+}
+
+fn impl_deref_provider_common(ast: &syn::DeriveInput) -> TokenStream {
+    let name = &ast.ident;
+    let gen = quote! {
+        impl std::ops::Deref for #name {
+            type Target = ProviderCommon;
+
+            fn deref(&self) -> &ProviderCommon {
+                self.as_provider_common()
+            }
+        }
+
+        impl DerefMut for #name {
+            fn deref_mut(&mut self) -> &mut ProviderCommon {
+                self.as_provider_common_mut()
+            }
+        }
+    };
+
+    gen.into()
+}

--- a/gd-world/Cargo.toml
+++ b/gd-world/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 gd-engine = { path = "../gd-engine/" }
+gd-world-derive = { path = "../gd-world-derive/" }
 rand = "0.6"
 docopt = "1"
 serde = "1.0"

--- a/gd-world/src/provider.rs
+++ b/gd-world/src/provider.rs
@@ -269,7 +269,7 @@ mod tests {
     use statrs::assert_almost_eq;
 
     #[test]
-    fn test_send_offer() {
+    fn send_offer() {
         let mut provider = ProviderCommon::new(Id::new(), 1.0, 1.0);
         provider.state = State::Idle;
 
@@ -281,7 +281,7 @@ mod tests {
     }
 
     #[test]
-    fn test_increase_profit_margin() {
+    fn increase_profit_margin() {
         let mut provider = ProviderCommon::new(Id::new(), 1.0, 1.0);
 
         assert_almost_eq!(provider.profit_margin, 1.0, 1e-5);
@@ -292,7 +292,7 @@ mod tests {
     }
 
     #[test]
-    fn test_decrease_profit_margin() {
+    fn decrease_profit_margin() {
         let mut provider = ProviderCommon::new(Id::new(), 1.0, 1.0);
 
         assert_almost_eq!(provider.profit_margin, 1.0, 1e-5);

--- a/gd-world/src/provider/linear_usage_inflation.rs
+++ b/gd-world/src/provider/linear_usage_inflation.rs
@@ -92,7 +92,7 @@ mod tests {
     use crate::task::SubTask;
 
     #[test]
-    fn linear_usage_inflation_provider_reported_usage() {
+    fn report_usage() {
         let mut provider = LinearUsageInflationProvider::new(0.1, 0.5, 1.0);
         let subtask = SubTask::new(100.0, 100.0);
         assert_almost_eq!(50.0, provider.report_usage(&subtask, 1.0), 1e-3);

--- a/gd-world/src/provider/linear_usage_inflation.rs
+++ b/gd-world/src/provider/linear_usage_inflation.rs
@@ -1,10 +1,12 @@
 use std::fmt;
 
+use gd_world_derive::DerefProviderCommon;
+
 use super::*;
 use crate::id::Id;
 use crate::task::SubTask;
 
-#[derive(Debug)]
+#[derive(Debug, DerefProviderCommon)]
 pub struct LinearUsageInflationProvider {
     inflation_factor: f64,
     common: ProviderCommon,
@@ -47,8 +49,8 @@ impl fmt::Display for LinearUsageInflationProvider {
 
 impl Provider for LinearUsageInflationProvider {
     fn report_usage(&self, subtask: &SubTask, bid: f64) -> f64 {
-        let intercept = self.common.usage_factor() * subtask.nominal_usage;
-        let usage = self.common.num_subtasks_computed as f64 * self.inflation_factor + intercept;
+        let intercept = self.usage_factor() * subtask.nominal_usage;
+        let usage = self.num_subtasks_computed as f64 * self.inflation_factor + intercept;
 
         usage.min(subtask.budget / bid)
     }
@@ -57,14 +59,14 @@ impl Provider for LinearUsageInflationProvider {
         Stats {
             run_id: run_id,
             behaviour: Behaviour::LinearUsageInflation,
-            min_price: self.common.min_price,
-            usage_factor: self.common.usage_factor,
-            profit_margin: self.common.profit_margin,
-            price: self.common.price(),
-            revenue: self.common.revenue,
-            num_subtasks_assigned: self.common.num_subtasks_assigned,
-            num_subtasks_computed: self.common.num_subtasks_computed,
-            num_subtasks_cancelled: self.common.num_subtasks_cancelled,
+            min_price: self.min_price,
+            usage_factor: self.usage_factor,
+            profit_margin: self.profit_margin,
+            price: self.price(),
+            revenue: self.revenue,
+            num_subtasks_assigned: self.num_subtasks_assigned,
+            num_subtasks_computed: self.num_subtasks_computed,
+            num_subtasks_cancelled: self.num_subtasks_cancelled,
         }
     }
 
@@ -95,16 +97,16 @@ mod tests {
         let subtask = SubTask::new(100.0, 100.0);
         assert_almost_eq!(50.0, provider.report_usage(&subtask, 1.0), 1e-3);
 
-        provider.as_provider_common_mut().num_subtasks_computed = 1;
+        provider.num_subtasks_computed = 1;
         assert_almost_eq!(51.0, provider.report_usage(&subtask, 1.0), 1e-3);
 
-        provider.as_provider_common_mut().num_subtasks_computed = 50;
+        provider.num_subtasks_computed = 50;
         assert_almost_eq!(100.0, provider.report_usage(&subtask, 1.0), 1e-3);
 
-        provider.as_provider_common_mut().num_subtasks_computed = 51;
+        provider.num_subtasks_computed = 51;
         assert_almost_eq!(100.0, provider.report_usage(&subtask, 1.0), 1e-3);
 
-        provider.as_provider_common_mut().num_subtasks_computed = 100;
+        provider.num_subtasks_computed = 100;
         assert_almost_eq!(100.0, provider.report_usage(&subtask, 1.0), 1e-3);
     }
 }

--- a/gd-world/src/provider/regular.rs
+++ b/gd-world/src/provider/regular.rs
@@ -66,3 +66,28 @@ impl Provider for RegularProvider {
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use statrs::assert_almost_eq;
+
+    use crate::task::SubTask;
+
+    #[test]
+    fn report_usage() {
+        let mut provider = RegularProvider::new(0.1, 0.25);
+        let subtask = SubTask::new(100.0, 100.0);
+
+        assert_almost_eq!(provider.report_usage(&subtask, 0.1), 25.0, 1e-6);
+        assert_almost_eq!(provider.report_usage(&subtask, 0.5), 25.0, 1e-6);
+        assert_almost_eq!(provider.report_usage(&subtask, 1.0), 25.0, 1e-6);
+
+        provider.usage_factor = 0.75;
+
+        assert_almost_eq!(provider.report_usage(&subtask, 0.1), 75.0, 1e-6);
+        assert_almost_eq!(provider.report_usage(&subtask, 0.5), 75.0, 1e-6);
+        assert_almost_eq!(provider.report_usage(&subtask, 1.0), 75.0, 1e-6);
+    }
+}

--- a/gd-world/src/provider/regular.rs
+++ b/gd-world/src/provider/regular.rs
@@ -1,9 +1,11 @@
 use std::fmt;
 
+use gd_world_derive::DerefProviderCommon;
+
 use super::*;
 use crate::task::SubTask;
 
-#[derive(Debug)]
+#[derive(Debug, DerefProviderCommon)]
 pub struct RegularProvider {
     common: ProviderCommon,
 }
@@ -34,21 +36,21 @@ impl fmt::Display for RegularProvider {
 
 impl Provider for RegularProvider {
     fn report_usage(&self, subtask: &SubTask, _bid: f64) -> f64 {
-        subtask.nominal_usage * self.common.usage_factor()
+        subtask.nominal_usage * self.usage_factor()
     }
 
     fn into_stats(self: Box<Self>, run_id: u64) -> Stats {
         Stats {
             run_id: run_id,
             behaviour: Behaviour::Regular,
-            min_price: self.common.min_price,
-            usage_factor: self.common.usage_factor,
-            profit_margin: self.common.profit_margin,
-            price: self.common.price(),
-            revenue: self.common.revenue,
-            num_subtasks_assigned: self.common.num_subtasks_assigned,
-            num_subtasks_computed: self.common.num_subtasks_computed,
-            num_subtasks_cancelled: self.common.num_subtasks_cancelled,
+            min_price: self.min_price,
+            usage_factor: self.usage_factor,
+            profit_margin: self.profit_margin,
+            price: self.price(),
+            revenue: self.revenue,
+            num_subtasks_assigned: self.num_subtasks_assigned,
+            num_subtasks_computed: self.num_subtasks_computed,
+            num_subtasks_cancelled: self.num_subtasks_cancelled,
         }
     }
 

--- a/gd-world/src/provider/undercut_budget.rs
+++ b/gd-world/src/provider/undercut_budget.rs
@@ -1,9 +1,11 @@
 use std::fmt;
 
+use gd_world_derive::DerefProviderCommon;
+
 use super::*;
 use crate::task::SubTask;
 
-#[derive(Debug)]
+#[derive(Debug, DerefProviderCommon)]
 pub struct UndercutBudgetProvider {
     epsilon: f64,
     common: ProviderCommon,
@@ -49,14 +51,14 @@ impl Provider for UndercutBudgetProvider {
         Stats {
             run_id: run_id,
             behaviour: Behaviour::UndercutBudget,
-            min_price: self.common.min_price,
-            usage_factor: self.common.usage_factor,
-            profit_margin: self.common.profit_margin,
-            price: self.common.price(),
-            revenue: self.common.revenue,
-            num_subtasks_assigned: self.common.num_subtasks_assigned,
-            num_subtasks_computed: self.common.num_subtasks_computed,
-            num_subtasks_cancelled: self.common.num_subtasks_cancelled,
+            min_price: self.min_price,
+            usage_factor: self.usage_factor,
+            profit_margin: self.profit_margin,
+            price: self.price(),
+            revenue: self.revenue,
+            num_subtasks_assigned: self.num_subtasks_assigned,
+            num_subtasks_computed: self.num_subtasks_computed,
+            num_subtasks_cancelled: self.num_subtasks_cancelled,
         }
     }
 
@@ -72,3 +74,4 @@ impl Provider for UndercutBudgetProvider {
         self
     }
 }
+

--- a/gd-world/src/provider/undercut_budget.rs
+++ b/gd-world/src/provider/undercut_budget.rs
@@ -75,3 +75,25 @@ impl Provider for UndercutBudgetProvider {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use statrs::assert_almost_eq;
+
+    use crate::task::SubTask;
+
+    #[test]
+    fn report_usage() {
+        let mut provider = UndercutBudgetProvider::new(0.1, 0.1, 0.0);
+        let subtask = SubTask::new(100.0, 100.0);
+
+        assert_almost_eq!(provider.report_usage(&subtask, 1.0), 100.0, 1e-6);
+        assert_almost_eq!(provider.report_usage(&subtask, 0.1) * 0.1, 100.0, 1e-6);
+
+        provider.epsilon = 0.5;
+
+        assert_almost_eq!(provider.report_usage(&subtask, 1.0), 50.0, 1e-6);
+        assert_almost_eq!(provider.report_usage(&subtask, 0.1) * 0.1, 50.0, 1e-6);
+    }
+}

--- a/gd-world/src/requestor.rs
+++ b/gd-world/src/requestor.rs
@@ -251,7 +251,7 @@ mod tests {
     use statrs::assert_almost_eq;
 
     #[test]
-    fn test_send_payment() {
+    fn send_payment() {
         let mut requestor = Requestor::new(1.0, 1.0, DefenceMechanismType::Redundancy);
         let p1 = (SubTask::new(100.0, 100.0), Id::new(), 0.1, 50.0); // (subtask, provider_id, bid, usage)
 
@@ -262,7 +262,7 @@ mod tests {
     }
 
     #[test]
-    fn test_complete_task() {
+    fn complete_task() {
         let mut requestor = Requestor::new(1.0, 1.0, DefenceMechanismType::Redundancy);
         let task = Task::new();
         requestor.task_queue.push(task.clone());

--- a/gd-world/src/requestor/defence.rs
+++ b/gd-world/src/requestor/defence.rs
@@ -190,7 +190,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_rank_offers() {
+    fn rank_offers() {
         let mut dm = DefenceMechanismCommon::new(Id::new());
         let bid1 = (Id::new(), 2.5); // (provider_id, bid/offer)
         let bid2 = (Id::new(), 0.5);
@@ -201,7 +201,7 @@ mod tests {
     }
 
     #[test]
-    fn test_filter_offers() {
+    fn filter_offers() {
         let mut dm = DefenceMechanismCommon::new(Id::new());
         let bid1 = (Id::new(), 1.0); // (provider_id, bid/offer)
         let bid2 = (Id::new(), 2.0);
@@ -216,7 +216,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_provider_rating() {
+    fn update_provider_rating() {
         let mut dm = DefenceMechanismCommon::new(Id::new());
         let provider = (Id::new(), 0.25);
 

--- a/gd-world/src/requestor/defence/ctasks.rs
+++ b/gd-world/src/requestor/defence/ctasks.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
-use std::ops::{Deref, DerefMut};
 
+use gd_world_derive::DerefDefenceMechanismCommon;
 use log::debug;
 use statrs::statistics::Statistics;
 
@@ -10,7 +10,7 @@ use crate::id::Id;
 use crate::task::subtask;
 use crate::task::{SubTask, Task};
 
-#[derive(Debug)]
+#[derive(Debug, DerefDefenceMechanismCommon)]
 pub struct CTasks {
     common: DefenceMechanismCommon,
     task_usages: HashMap<Id, Vec<f64>>,
@@ -116,20 +116,6 @@ impl DefenceMechanism for CTasks {
 
     fn as_dm_common_mut(&mut self) -> &mut DefenceMechanismCommon {
         &mut self.common
-    }
-}
-
-impl Deref for CTasks {
-    type Target = DefenceMechanismCommon;
-
-    fn deref(&self) -> &DefenceMechanismCommon {
-        self.as_dm_common()
-    }
-}
-
-impl DerefMut for CTasks {
-    fn deref_mut(&mut self) -> &mut DefenceMechanismCommon {
-        self.as_dm_common_mut()
     }
 }
 

--- a/gd-world/src/requestor/defence/ctasks.rs
+++ b/gd-world/src/requestor/defence/ctasks.rs
@@ -126,7 +126,7 @@ mod tests {
     use statrs::assert_almost_eq;
 
     #[test]
-    fn test_assign_subtasks() {
+    fn assign_subtasks() {
         let mut ctasks = CTasks::new(Id::new());
         let s1 = SubTask::new(1.0, 1.0);
         let s2 = SubTask::new(1.0, 1.0);
@@ -145,7 +145,7 @@ mod tests {
     }
 
     #[test]
-    fn test_complete_task() {
+    fn complete_task() {
         let mut ctasks = CTasks::new(Id::new());
 
         let id1 = Id::new();

--- a/gd-world/src/requestor/defence/lgrola.rs
+++ b/gd-world/src/requestor/defence/lgrola.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
-use std::ops::{Deref, DerefMut};
 
+use gd_world_derive::DerefDefenceMechanismCommon;
 use log::debug;
 use statrs::statistics::{OrderStatistics, Statistics};
 
@@ -10,7 +10,7 @@ use crate::id::Id;
 use crate::task::subtask;
 use crate::task::{SubTask, Task};
 
-#[derive(Debug)]
+#[derive(Debug, DerefDefenceMechanismCommon)]
 pub struct LGRola {
     common: DefenceMechanismCommon,
     task_usages: HashMap<Id, Vec<f64>>,
@@ -153,20 +153,6 @@ impl DefenceMechanism for LGRola {
 
     fn as_dm_common_mut(&mut self) -> &mut DefenceMechanismCommon {
         &mut self.common
-    }
-}
-
-impl Deref for LGRola {
-    type Target = DefenceMechanismCommon;
-
-    fn deref(&self) -> &DefenceMechanismCommon {
-        self.as_dm_common()
-    }
-}
-
-impl DerefMut for LGRola {
-    fn deref_mut(&mut self) -> &mut DefenceMechanismCommon {
-        self.as_dm_common_mut()
     }
 }
 

--- a/gd-world/src/requestor/defence/lgrola.rs
+++ b/gd-world/src/requestor/defence/lgrola.rs
@@ -161,7 +161,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_assign_subtasks() {
+    fn assign_subtasks() {
         let mut lgrola = LGRola::new(Id::new());
         let s1 = SubTask::new(1.0, 1.0);
         let s2 = SubTask::new(1.0, 1.0);
@@ -180,7 +180,7 @@ mod tests {
     }
 
     #[test]
-    fn test_complete_task() {
+    fn complete_task() {
         let mut lgrola = LGRola::new(Id::new());
 
         for _ in 0..25 {

--- a/gd-world/src/requestor/defence/redundancy.rs
+++ b/gd-world/src/requestor/defence/redundancy.rs
@@ -162,7 +162,7 @@ mod tests {
     use statrs::assert_almost_eq;
 
     #[test]
-    fn test_insert_verification() {
+    fn insert_verification() {
         let mut vmap = VerificationMap::new();
         let id = Id::new();
         vmap.insert_key(id);
@@ -200,7 +200,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_rating() {
+    fn update_rating() {
         let mut redundancy = Redundancy::new(Id::new());
         let p1 = (Id::new(), 0.25, 25.0); // (provider_id, rating, usage)
         let p2 = (Id::new(), 0.75, 75.0);
@@ -227,7 +227,7 @@ mod tests {
     }
 
     #[test]
-    fn test_assign_subtasks() {
+    fn assign_subtasks() {
         let mut redundancy = Redundancy::new(Id::new());
         let subtask = SubTask::new(1.0, 1.0);
         let mut task = Task::new();
@@ -244,7 +244,7 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_subtask_successful() {
+    fn verify_subtask_successful() {
         let mut redundancy = Redundancy::new(Id::new());
 
         let p1 = (Id::new(), 0.25, 100.0);
@@ -266,7 +266,7 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_subtask_partial_success() {
+    fn verify_subtask_partial_success() {
         {
             let mut redundancy = Redundancy::new(Id::new());
 
@@ -311,7 +311,7 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_subtask_failed() {
+    fn verify_subtask_failed() {
         let mut redundancy = Redundancy::new(Id::new());
 
         let p1 = (Id::new(), 0.25, 100.0);

--- a/gd-world/src/requestor/defence/redundancy.rs
+++ b/gd-world/src/requestor/defence/redundancy.rs
@@ -1,8 +1,8 @@
 use super::{DefenceMechanism, DefenceMechanismCommon};
 
 use std::collections::HashMap;
-use std::ops::{Deref, DerefMut};
 
+use gd_world_derive::DerefDefenceMechanismCommon;
 use log::debug;
 
 use crate::id::Id;
@@ -51,7 +51,7 @@ impl VerificationMap {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, DerefDefenceMechanismCommon)]
 pub struct Redundancy {
     common: DefenceMechanismCommon,
     verification_map: VerificationMap,
@@ -152,20 +152,6 @@ impl DefenceMechanism for Redundancy {
 
     fn as_dm_common_mut(&mut self) -> &mut DefenceMechanismCommon {
         &mut self.common
-    }
-}
-
-impl Deref for Redundancy {
-    type Target = DefenceMechanismCommon;
-
-    fn deref(&self) -> &DefenceMechanismCommon {
-        self.as_dm_common()
-    }
-}
-
-impl DerefMut for Redundancy {
-    fn deref_mut(&mut self) -> &mut DefenceMechanismCommon {
-        self.as_dm_common_mut()
     }
 }
 

--- a/gd-world/src/requestor/task_queue.rs
+++ b/gd-world/src/requestor/task_queue.rs
@@ -42,7 +42,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_pop_repeating() {
+    fn pop_repeating() {
         let mut task_queue = TaskQueue::new();
 
         assert!(task_queue.repeating);
@@ -55,7 +55,7 @@ mod tests {
     }
 
     #[test]
-    fn test_pop_nonrepeating() {
+    fn pop_nonrepeating() {
         let mut task_queue = TaskQueue::new();
         task_queue.repeating = false;
 

--- a/gd-world/src/task.rs
+++ b/gd-world/src/task.rs
@@ -117,7 +117,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_task_states() {
+    fn task_states() {
         let mut task = Task::new();
 
         assert!(!task.is_pending());


### PR DESCRIPTION
* use procedural-macro to derive derefs for DefenseMechanismCommon and ProviderCommon
* refactor unit tests' names